### PR TITLE
setup.py: Add long description for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     name="artagger",
     version="0.1.3",
     description="A Ripple Down Rules-based (RDR) Part-Of-Speech Tagger implementation based on RDRPOSTagger.",
-    # other arguments omitted
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Frans Huang",
@@ -26,6 +25,13 @@ setup(
     include_package_data=True,
     license="MIT",
     zip_safe=False,
+    keywords=[
+        "NLP",
+        "natural language processing",
+        "part-of-speech tagger",
+        "text analytics",
+        "text processing",
+    ],
     classifiers=[
         "Intended Audience :: Developers",
         "Natural Language :: Thai",

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,35 @@
+from os import path
+
 from setuptools import setup
 
+# Read the contents of README file
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
+
 setup(
-    name='artagger',
-    version='0.1.2',
-    description='RDRPOSTagger Implementation.',
-    author='Frans Huang',
-    author_email='franssiswanto@gmail.com',
-    url='https://github.com/franziz/artagger/',
-    packages=["artagger", "artagger.InitialTagger", "artagger.SCRDRlearner", "artagger.Utility"],
+    name="artagger",
+    version="0.1.3",
+    description="A Ripple Down Rules-based (RDR) Part-Of-Speech Tagger implementation based on RDRPOSTagger.",
+    # other arguments omitted
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="Frans Huang",
+    author_email="franssiswanto@gmail.com",
+    url="https://github.com/franziz/artagger/",
+    packages=[
+        "artagger",
+        "artagger.InitialTagger",
+        "artagger.SCRDRlearner",
+        "artagger.Utility",
+    ],
     include_package_data=True,
-    license='MIT',
+    license="MIT",
     zip_safe=False,
     classifiers=[
-        'Programming Language :: Python :: 3',
-        'Intended Audience :: Developers',
+        "Intended Audience :: Developers",
+        "Natural Language :: Thai",
+        "Programming Language :: Python :: 3",
+        "Topic :: Text Processing :: Linguistic",
     ],
 )


### PR DESCRIPTION
- Add README.md as long description in setup.py for PyPI to use
- Update version to 1.0.3 to sync with PyPI
- Add more classifiers

Question:
- Licese in in setup.py is "MIT", but in GitHub is "Apache License 2.0"